### PR TITLE
Add run mode selection via CLI or env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,7 @@ LOG_ERRORS_FILE=errors.log
 
 # === Admin ===
 ADMIN_ID=123456789
+
+# === Run Mode ===
+# "polling" for long polling or "webhook" for webhook listener
+RUN_MODE=webhook

--- a/README.md
+++ b/README.md
@@ -69,16 +69,20 @@ Ideal for developers looking to use async handlers, webhook-based updates, and m
 - `LOG_BOT_FILE`: Filename for general bot logs.
 - `LOG_ERRORS_FILE`: Filename for error logs.
 - `ADMIN_ID`: Telegram user ID with admin rights.
+- `RUN_MODE`: `polling` for development or `webhook` for production.
 
-5. Start the bot (for development):
+You can also set the `RUN_MODE` environment variable instead of using
+the `--mode` command-line option.
+
+5. Start the bot in polling mode (development):
    ```bash
-   python main.py
+   python main.py --mode polling
    ```
 
 Or run as a webhook listener (recommended for production):
 
 ```bash
-python main.py
+python main.py --mode webhook
 ```
 
 ## Production

--- a/config.py
+++ b/config.py
@@ -39,6 +39,10 @@ LOG_ERRORS_FILE = os.getenv("LOG_ERRORS_FILE", "errors.log")
 # Telegram user ID with admin access to the bot
 ADMIN_ID = int(os.getenv("ADMIN_ID") or 0)  # Telegram user ID with admin access
 
+# === Run Mode ===
+# Select between 'polling' or 'webhook' startup modes
+RUN_MODE = os.getenv("RUN_MODE", "webhook").lower()
+
 
 # === Validation ===
 # Ensures that required environment variables are defined before the bot starts

--- a/core/runner.py
+++ b/core/runner.py
@@ -5,7 +5,7 @@ and startup mode (polling or webhook). Provides entry points for bot execution
 and integrates logging, command registration, and graceful exception handling.
 """
 
-from config import BOT_TOKEN, WEBHOOK_LISTEN, WEBHOOK_PORT, WEBHOOK_URL
+from config import BOT_TOKEN, RUN_MODE, WEBHOOK_LISTEN, WEBHOOK_PORT, WEBHOOK_URL
 from core.error_handler import handle_error
 from handlers.fallback import unknown_command
 from handlers_loader import register_handlers
@@ -44,10 +44,25 @@ def run_webhook() -> None:
     start_webhook(app)
 
 
-def run_telegram_bot() -> None:
-    """Entry point to run the bot with webhook. Handles startup exceptions."""
+def start_polling(app: Application) -> None:
+    """Start the bot using Application.run_polling."""
+    logger.info("🚀 Launching polling mode")
+    app.run_polling()
+
+
+def run_polling() -> None:
+    """Build the bot application and run it in polling mode."""
+    app = create_application()
+    start_polling(app)
+
+
+def run_telegram_bot(mode: str = RUN_MODE) -> None:
+    """Entry point to run the bot in polling or webhook mode."""
     try:
-        run_webhook()
+        if mode == "polling":
+            run_polling()
+        else:
+            run_webhook()
     except (OSError, RuntimeError) as e:
         logger.exception("🚨 Bot failed to start: %s", e)
         import time

--- a/main.py
+++ b/main.py
@@ -4,10 +4,11 @@ This script sets up logging, checks environment variables,
 and runs the bot using the run_telegram_bot function.
 """
 
+import argparse
 import logging
 import sys
 
-from config import validate_config
+from config import RUN_MODE, validate_config
 from core.runner import run_telegram_bot
 from utils.environment import check_environment
 from utils.logger import setup_logging
@@ -16,6 +17,14 @@ from utils.logger import setup_logging
 def main() -> None:
     """Set up environment and run the Telegram bot."""
     setup_logging()
+    parser = argparse.ArgumentParser(description="Telegram Bot")
+    parser.add_argument(
+        "--mode",
+        choices=["polling", "webhook"],
+        default=RUN_MODE,
+        help="Run mode: polling or webhook",
+    )
+    args = parser.parse_args()
     startup_logger = logging.getLogger("startup")
     try:
         validate_config()
@@ -23,8 +32,8 @@ def main() -> None:
         startup_logger.exception("Configuration error: %s", exc)
         sys.exit(1)
     check_environment()
-    startup_logger.info("🚀 Starting Telegram Bot")
-    run_telegram_bot()
+    startup_logger.info("🚀 Starting Telegram Bot in %s mode", args.mode)
+    run_telegram_bot(args.mode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow selecting polling or webhook with RUN_MODE/--mode
- update example environment file
- document new option in README

## Testing
- `python -m py_compile config.py core/runner.py main.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68447d402874832abe29e9409ed163c1