### PR TITLE
Add basic tests and CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,25 @@
+name: Python application
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install pytest
+    - name: Run tests
+      run: pytest -v

--- a/README.md
+++ b/README.md
@@ -142,6 +142,14 @@ telegram_bot/
 └── README.md
 ```
 
+## Testing
+
+Run the test suite with [pytest](https://pytest.org/):
+
+```bash
+pytest
+```
+
 ## License
 
 MIT License

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,57 @@
+import asyncio
+
+import pytest
+
+from telegram import BotCommand
+
+import utils.commands as commands
+
+
+class DummyBot:
+    def __init__(self):
+        self.received = None
+
+    async def set_my_commands(self, commands_list):
+        self.received = commands_list
+
+
+class DummyApp:
+    def __init__(self):
+        self.bot = DummyBot()
+
+
+def test_command_registry_and_descriptions(monkeypatch):
+    registry: list[commands.CommandMeta] = []
+    monkeypatch.setattr(commands, "COMMAND_REGISTRY", registry, raising=False)
+
+    @commands.command("Foo command")
+    async def foo_command(update=None, context=None):
+        pass
+
+    @commands.command("Hidden", hidden=True)
+    async def hidden_command(update=None, context=None):
+        pass
+
+    assert registry[0].name == "foo"
+    assert registry[0].description == "Foo command"
+
+    assert commands.get_commands_descriptions() == "/foo — Foo command"
+
+
+def test_make_set_commands(monkeypatch):
+    registry: list[commands.CommandMeta] = []
+    monkeypatch.setattr(commands, "COMMAND_REGISTRY", registry, raising=False)
+
+    @commands.command("Foo")
+    async def foo_command(update=None, context=None):
+        pass
+
+    @commands.command("Bar", admin_only=True)
+    async def bar_command(update=None, context=None):
+        pass
+
+    app = DummyApp()
+    setter = commands.make_set_commands()
+    asyncio.run(setter(app))
+
+    assert app.bot.received == [BotCommand("foo", "Foo")]


### PR DESCRIPTION
## Summary
- add pytest test suite for utils.commands
- run tests with GitHub Actions
- document pytest command in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844954e3f7c832a94f5a2442d78f8d1