### PR TITLE
Format codebase and add typing

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,7 @@ Sections:
 
 Refer to `.env.example` for variable definitions.
 """
+
 import os
 
 from dotenv import load_dotenv

--- a/core/error_handler.py
+++ b/core/error_handler.py
@@ -3,6 +3,7 @@
 Captures and logs all exceptions raised during update processing,
 and optionally notifies the user with a fallback message.
 """
+
 import logging
 
 from telegram import Update
@@ -12,8 +13,7 @@ from telegram.ext import ContextTypes
 async def handle_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle errors raised during update processing and optionally notify the user."""
     logging.getLogger("errors").error(
-        "Exception while handling an update:",
-        exc_info=context.error
+        "Exception while handling an update:", exc_info=context.error
     )
     if isinstance(update, Update) and update.effective_message:
         await update.effective_message.reply_text("⚠️ An unexpected error occurred.")

--- a/core/runner.py
+++ b/core/runner.py
@@ -5,11 +5,12 @@ and startup mode (polling or webhook). Provides entry points for bot execution
 and integrates logging, command registration, and graceful exception handling.
 """
 
+from telegram.ext import Application, ApplicationBuilder, MessageHandler, filters
+
 from config import BOT_TOKEN, RUN_MODE, WEBHOOK_LISTEN, WEBHOOK_PORT, WEBHOOK_URL
 from core.error_handler import handle_error
 from handlers.fallback import unknown_command
 from handlers_loader import register_handlers
-from telegram.ext import Application, ApplicationBuilder, MessageHandler, filters
 from utils.commands import make_set_commands
 from utils.logger import logger
 
@@ -66,5 +67,6 @@ def run_telegram_bot(mode: str = RUN_MODE) -> None:
     except (OSError, RuntimeError) as e:
         logger.exception("🚨 Bot failed to start: %s", e)
         import time
+
         logger.info("⏳ Waiting 5 seconds before exit to avoid restart loop...")
         time.sleep(5)

--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -2,15 +2,15 @@
 
 from telegram import Update
 from telegram.ext import ContextTypes
+
 from utils.commands import command
 from utils.decorators import admin_required
 
 
- # Registers an admin-only command with description shown in /help
+# Registers an admin-only command with description shown in /help
 @command("Secret admin command", admin_only=True)
- # Ensures only the admin (by ID) can run this command
+# Ensures only the admin (by ID) can run this command
 @admin_required
-
 async def secret_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> None:
     """Respond with a secret message for admins."""
     if update.message:

--- a/handlers/fallback.py
+++ b/handlers/fallback.py
@@ -8,6 +8,7 @@ import logging
 
 from telegram import Update
 from telegram.ext import ContextTypes
+
 from utils.commands import command
 
 logger = logging.getLogger("bot_bot")
@@ -17,8 +18,10 @@ logger = logging.getLogger("bot_bot")
 # Hidden commands are not shown in the /help listing.
 @command(hidden=True)
 
- # Handles any unknown slash commands like /wrong, logs them, and replies with a hint.
-async def unknown_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:  # noqa: ARG001
+# Handles any unknown slash commands like /wrong, logs them, and replies with a hint.
+async def unknown_command(
+    update: Update, context: ContextTypes.DEFAULT_TYPE
+) -> None:  # noqa: ARG001
     """Handle unknown slash commands and guide user to /help."""
     if update.message and update.message.text.startswith("/"):
         logger.warning("Unknown command received: %s", update.message.text)

--- a/handlers/help.py
+++ b/handlers/help.py
@@ -7,12 +7,12 @@ respects DEBUG mode to ensure fresh command list during development.
 
 from telegram import Update
 from telegram.ext import ContextTypes
+
 from utils.commands import command, get_commands_descriptions
 
 
 # Marks this function as a visible command with a description used in /help listing
 @command("Show available commands")
-
 async def help_command(update: Update, _context: ContextTypes.DEFAULT_TYPE) -> None:
     """Reply with a list of available commands."""
     text = "Use these commands to control me:\n\n"

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -7,14 +7,15 @@ import logging
 
 from telegram import Update
 from telegram.ext import ContextTypes
+
 from utils.commands import command
 from utils.markdown import escape_markdown
 
 logger = logging.getLogger("bot_bot")
 
+
 # Register the /start command with a description shown in /help
 @command("Launch the bot")
-
 async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Send greeting message to user on /start command."""
     # Log the received command for debugging
@@ -28,6 +29,6 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         "This is a base template for a Telegram bot.\n"
         "Use this bot as a starting point to build your own functionality.\n\n"
         "You can see the list of commands by typing /help.",
-        version=2
+        version=2,
     )
     await update.message.reply_text(text, parse_mode="MarkdownV2")

--- a/handlers_loader.py
+++ b/handlers_loader.py
@@ -6,11 +6,13 @@ from :mod:`utils.commands`, which appends metadata to ``COMMAND_REGISTRY``.
 Callback query handlers can still be declared via a ``__callbacks__`` dictionary
 inside each module.
 """
+
 import importlib
 import pkgutil
 
-import handlers
 from telegram.ext import Application, CallbackQueryHandler, CommandHandler
+
+import handlers
 from utils.commands import COMMAND_REGISTRY
 from utils.logger import logger
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,22 +1,30 @@
+"""Tests for command management utilities."""
+
+from __future__ import annotations
+
 import asyncio
 
 import pytest
-
 from telegram import BotCommand
 
 import utils.commands as commands
 
 
 class DummyBot:
-    def __init__(self):
-        self.received = None
+    """Minimal bot stub used for testing."""
 
-    async def set_my_commands(self, commands_list):
+    def __init__(self) -> None:
+        self.received: list[BotCommand] | None = None
+
+    async def set_my_commands(self, commands_list: list[BotCommand]) -> None:
+        """Record the commands that would be set."""
         self.received = commands_list
 
 
 class DummyApp:
-    def __init__(self):
+    """Application stub exposing only the bot property."""
+
+    def __init__(self) -> None:
         self.bot = DummyBot()
 
 

--- a/utils/commands.py
+++ b/utils/commands.py
@@ -3,6 +3,7 @@
 Provides helper functions and helpers for registering command handlers and
 generating their descriptions for the bot's command list.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -38,7 +39,9 @@ def command(
 ) -> Callable[[Callable[..., Awaitable[None]]], Callable[..., Awaitable[None]]]:
     """Register a command handler with optional metadata."""
 
-    def decorator(func: Callable[..., Awaitable[None]]) -> Callable[..., Awaitable[None]]:  # noqa: E501
+    def decorator(
+        func: Callable[..., Awaitable[None]],
+    ) -> Callable[..., Awaitable[None]]:  # noqa: E501
         command_name = func.__name__.replace("_command", "")
         COMMAND_REGISTRY.append(
             CommandMeta(
@@ -67,6 +70,7 @@ def make_set_commands() -> Callable[[Application], Awaitable[None]]:
         await application.bot.set_my_commands(commands)
 
     return set_commands
+
 
 def get_commands_descriptions() -> str:
     """Return a formatted string of all visible bot commands and their descriptions."""

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -10,12 +10,15 @@ from collections.abc import Awaitable, Callable
 from functools import wraps
 from typing import Any
 
-from config import ADMIN_ID
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from config import ADMIN_ID
 
-def admin_required(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:  # noqa: E501
+
+def admin_required(
+    func: Callable[..., Awaitable[Any]],
+) -> Callable[..., Awaitable[Any]]:  # noqa: E501
     """Allow execution only for the configured ADMIN_ID."""
 
     @wraps(func)

--- a/utils/environment.py
+++ b/utils/environment.py
@@ -4,6 +4,7 @@ Provides a single-responsibility function to log key environment details
 such as Python version, OS platform, aiohttp, and python-telegram-bot versions.
 Intended to be used at bot startup for diagnostic logging.
 """
+
 import logging
 import platform
 
@@ -11,6 +12,7 @@ import aiohttp
 import telegram
 
 startup_logger = logging.getLogger("startup")
+
 
 def check_environment() -> None:
     """Log basic environment details such as Python, OS, and library versions."""

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -4,6 +4,7 @@ Initializes loggers with rotating file handlers, separate log files for componen
 and colored console output using Colorama. Integrates multiple log levels and
 structured formatting with support for user tagging in log messages.
 """
+
 import logging
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -11,6 +12,7 @@ from typing import ClassVar
 
 from colorama import Fore, Style
 from colorama import init as colorama_init
+
 from config import (  # Import log level and log directory from centralized config
     LOG_BOT_FILE,
     LOG_DIR,
@@ -19,6 +21,7 @@ from config import (  # Import log level and log directory from centralized conf
 )
 
 colorama_init()
+
 
 # ColorFormatter for pretty colored logs in console
 class ColorFormatter(logging.Formatter):
@@ -29,7 +32,7 @@ class ColorFormatter(logging.Formatter):
         logging.INFO: Fore.GREEN,
         logging.WARNING: Fore.YELLOW,
         logging.ERROR: Fore.RED,
-        logging.CRITICAL: Fore.MAGENTA
+        logging.CRITICAL: Fore.MAGENTA,
     }
 
     def format(self, record: logging.LogRecord) -> str:
@@ -51,6 +54,7 @@ class ColorFormatter(logging.Formatter):
             message += f" | 👤 {user_display}"
         return f"{color}{message}{reset}"
 
+
 def configure_logger(name: str, handlers: list[logging.Handler], level: int) -> None:
     """Configure a logger with the given handlers and log level."""
     logger = logging.getLogger(name)
@@ -58,6 +62,7 @@ def configure_logger(name: str, handlers: list[logging.Handler], level: int) -> 
         logger.setLevel(level)
     for handler in handlers:
         logger.addHandler(handler)
+
 
 def setup_logging() -> None:
     """Set up logging with rotating files, color console output, and level filtering."""
@@ -94,13 +99,13 @@ def setup_logging() -> None:
     configure_logger(
         "bot_bot",
         [rotating_bot_handler, console_handler],
-        getattr(logging, LOG_LEVEL, logging.DEBUG)
+        getattr(logging, LOG_LEVEL, logging.DEBUG),
     )
 
     configure_logger(
         "startup",
         [console_handler, rotating_bot_handler],
-        getattr(logging, LOG_LEVEL, logging.INFO)
+        getattr(logging, LOG_LEVEL, logging.INFO),
     )
 
     configure_logger(
@@ -108,5 +113,6 @@ def setup_logging() -> None:
         [error_handler, rotating_bot_handler],
         logging.ERROR,
     )
+
 
 logger = logging.getLogger("bot_bot")

--- a/utils/markdown.py
+++ b/utils/markdown.py
@@ -4,6 +4,7 @@ Provides a version-aware function to escape special Markdown characters
 required by Telegram's MarkdownV1 and MarkdownV2 formats. Supports
 entity-type specific escaping for safer formatting in messages.
 """
+
 import logging
 import re
 
@@ -11,6 +12,7 @@ TELEGRAM_MD_V1 = 1
 TELEGRAM_MD_V2 = 2
 
 logger = logging.getLogger("bot_bot")
+
 
 def escape_markdown(text: str, version: int = 2, entity_type: str | None = None) -> str:
     """Escape Telegram Markdown special characters for MarkdownV1 or MarkdownV2.


### PR DESCRIPTION
## Summary
- run `black` and `isort`
- add missing typing and module docstring in tests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68449a13ec84832abb99d88453d410d8